### PR TITLE
Add clk_flags to configuration options.

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -23,6 +23,7 @@ mrb_esp32_i2c_init(mrb_state *mrb, mrb_value self)
   conf.scl_pullup_en = scl_pullup;
   conf.sda_pullup_en = sda_pullup;
   conf.master.clk_speed = freq;
+  conf.clk_flags = I2C_SCLK_SRC_FLAG_FOR_NOMAL;
 
   i2c_param_config(port, &conf);
   i2c_driver_install(port, mode, 0, 0, 0);


### PR DESCRIPTION
The i2c_param_config() in esp-idf release/v5.1 requires clk_flags.

https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/api-reference/peripherals/i2c.html?highlight=clk_flags#source-clock-configuration

How to avoid build errors

Please turn on the backward compatibility flag "CONFIG_FREERTOS_ENABLE_BACKWARD_COMPATIBILITY" in  menuconfig.
```
idf.py menuconfig
```

to set `configENABLE_BACKWARD_COMPATIBILITY`
```
(Top) → Component config → FreeRTOS → Kernel

before
[ ] configENABLE_BACKWARD_COMPATIBILITY

after
[*] configENABLE_BACKWARD_COMPATIBILITY
```